### PR TITLE
Upgraded version ElasticSearch to 5.5.2 because 5.2.2 deprecated for …

### DIFF
--- a/java-log-aggregation/docker-compose.yml
+++ b/java-log-aggregation/docker-compose.yml
@@ -11,7 +11,7 @@ services:
    - front-tier
 
  elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.2.2
+  image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
   container_name: elasticsearch
   environment:
     - cluster.name=docker-cluster


### PR DESCRIPTION
…Kibana